### PR TITLE
Makefile: implement GNU Coding Standard for Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ OUT := qmic
 
 CFLAGS := -Wall -g -O2
 LDFLAGS :=
+prefix := /usr/local
 
 SRCS := qmic.c qmi_message.c qmi_struct.c
 OBJS := $(SRCS:.c=.o)
@@ -10,7 +11,7 @@ $(OUT): $(OBJS)
 	$(CC) $(LDFLAGS) -o $@ $^
 
 install: $(OUT)
-	install -D -m 755 $< $(PREFIX)/bin/$<
+	install -D -m 755 $< $(DESTDIR)$(prefix)/bin/$<
 
 clean:
 	rm -f $(OUT) $(OBJS)


### PR DESCRIPTION
GNU coding standards notably specifies:
* install files with the $(DESTDIR) to the target system image
* install files with the $(prefix), not $(PREFIX)
* the default value of $(prefix) should be /usr/local

as per https://www.gnu.org/prep/standards/html_node/Directory-Variables.html.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>