### PR TITLE
Makefile: Allow compiler/linker flags to be overridden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 OUT := qmic
 
-CFLAGS := -Wall -g -O2
-LDFLAGS :=
-prefix := /usr/local
+CFLAGS ?= -Wall -g -O2
+LDFLAGS ?=
+prefix ?= /usr/local
 
 SRCS := qmic.c qmi_message.c qmi_struct.c
 OBJS := $(SRCS:.c=.o)


### PR DESCRIPTION
This helps with cross compilation where toolchains specify
certain flags via environment e.g. CFLAGS/LDFLAGS

Signed-off-by: Khem Raj <raj.khem@gmail.com>