### PR TITLE
parser: handle decimal '0' when parsing numbers

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -263,30 +263,28 @@ static int isodigit(int c)
 /* Extract a number from input into the given buffer; return base */
 static unsigned qmi_number_parse(char *buf, size_t size, char ch)
 {
-	int (*isvalid)(int);
+	int (*isvalid)(int) = isdigit;
 	char *p = buf;
-	unsigned base;
+	unsigned base = 10;
 
-	/* First character is a digit; determine base and valid character set */
+	/* First character is known to be a digit 0-9 */
+	*p++ = ch;
+
+	/* Determine base and valid character set */
 	if (ch == '0') {
-		*p++ = ch;
 		ch = input();
 		if (ch == 'x' || ch == 'X') {
 			*p++ = ch;
 			ch = input();
 			isvalid = isxdigit;
 			base = 16;
-		} else {
+		} else if (isodigit(ch)) {
 			isvalid = isodigit;
 			base = 8;
 		}
-	} else {
-		isvalid = isdigit;
-		base = 10;
+		unput(ch);
 	}
 
-	/* First character is known to be a digit 0-9 */
-	*p++ = ch;
 	while ((ch = input()) && isvalid(ch)) {
 		if (p - buf == size) {
 			buf[TOKEN_BUF_MIN] = '\0';

--- a/tests/single_digit_decimal.qmi
+++ b/tests/single_digit_decimal.qmi
@@ -1,0 +1,22 @@
+package test;
+
+const TEST_SINGLE_DIGIT_ZERO = 0;
+const TEST_SINGLE_DIGIT_N = 5;
+
+struct qmi_result {
+	u16 result;
+	u16 error;
+};
+
+request test_request {
+	required u8 test_single_digit_bracket(5) = 0;
+	required u8 zero_brackets(0) = 1;
+} = 0x23;
+
+response test_response {
+	required qmi_result r = 20;
+} = 043;
+
+indication test_indication {
+	optional u64 value = 0x99;
+} = 0x7;


### PR DESCRIPTION
The commit 61f6fe9d1c4c ("parser: be more restrictive when parsing numbers")
introduced a bug where having a single '0' would cause a parser error
due to the base handling logic swallowing the `;`. Fix this
and add a test to check for it.

I wound up reworking the logic here to try and simplify things a bit, though I'm not sure how successful I was there...