### PR TITLE
[RFC] accessor: support QMI_CTL packets

### DIFF
--- a/accessor.c
+++ b/accessor.c
@@ -132,23 +132,24 @@ static void qmi_message_emit_message(FILE *fp,
 				     const char *package,
 				     struct qmi_message *qm)
 {
+	printf("%s\n", qm->name);
 	fprintf(fp, "struct %1$s_%2$s *%1$s_%2$s_alloc(unsigned txn)\n"
 		    "{\n"
-		    "	return (struct %1$s_%2$s*)qmi_tlv_init(txn, %3$d, %4$d);\n"
+		    "	return (struct %1$s_%2$s*)qmi_tlv_init%3$s(txn, %4$d, %5$d);\n"
 		    "}\n\n",
-		    package, qm->name, qm->msg_id, qm->type);
+		    package, qm->name, qm->is_ctl ? "_ctl" : "", qm->msg_id, qm->type);
 
 	fprintf(fp, "struct %1$s_%2$s *%1$s_%2$s_parse(void *buf, size_t len, unsigned *txn)\n"
 		    "{\n"
-		    "	return (struct %1$s_%2$s*)qmi_tlv_decode(buf, len, txn, %3$d);\n"
+		    "	return (struct %1$s_%2$s*)qmi_tlv_decode%3$s(buf, len, txn, %4$d);\n"
 		    "}\n\n",
-		    package, qm->name, qm->type);
+		    package, qm->name, qm->is_ctl ? "_ctl" : "", qm->type);
 
-	fprintf(fp, "void *%1$s_%2$s_encode(struct %1$s_%2$s *%2$s, size_t *len)\n"
+	fprintf(fp, "void *%1$s_%3$s_encode(struct %1$s_%3$s *%3$s, size_t *len)\n"
 		    "{\n"
-		    "	return qmi_tlv_encode((struct qmi_tlv*)%2$s, len);\n"
+		    "	return qmi_tlv_encode%2$s((struct qmi_tlv*)%3$s, len);\n"
 		    "}\n\n",
-		    package, qm->name);
+		    package, qm->is_ctl ? "_ctl" : "", qm->name);
 
 	fprintf(fp, "void %1$s_%2$s_free(struct %1$s_%2$s *%2$s)\n"
 		    "{\n"
@@ -347,8 +348,11 @@ static void emit_header_file_header(FILE *fp)
 	fprintf(fp, "struct qmi_tlv;\n"
 		    "\n"
 		    "struct qmi_tlv *qmi_tlv_init(unsigned txn, unsigned msg_id, unsigned type);\n"
+		    "struct qmi_tlv *qmi_tlv_init_ctl(unsigned txn, unsigned msg_id, unsigned type);\n"
 		    "struct qmi_tlv *qmi_tlv_decode(void *buf, size_t len, unsigned *txn, unsigned type);\n"
+		    "struct qmi_tlv *qmi_tlv_decode_ctl(void *buf, size_t len, unsigned *txn, unsigned type);\n"
 		    "void *qmi_tlv_encode(struct qmi_tlv *tlv, size_t *len);\n"
+		    "void *qmi_tlv_encode_ctl(struct qmi_tlv *tlv, size_t *len);\n"
 		    "void qmi_tlv_free(struct qmi_tlv *tlv);\n"
 		    "\n"
 		    "void *qmi_tlv_get(struct qmi_tlv *tlv, unsigned id, size_t *len);\n"

--- a/parser.c
+++ b/parser.c
@@ -48,6 +48,7 @@ enum token_id {
 	TOK_TYPE,
 	TOK_REQUIRED,
 	TOK_OPTIONAL,
+	TOK_CTL,
 	TOK_EOF,
 };
 
@@ -449,12 +450,15 @@ static void qmi_message_parse(enum message_type message_type)
 	unsigned array_size;
 	bool array_fixed;
 	bool required;
+	bool is_ctl = token_accept(TOK_CTL, NULL);
 
 	token_expect(TOK_ID, &msg_id_tok);
 	token_expect('{', NULL);
 
 	qm = memalloc(sizeof(struct qmi_message));
 	qm->name = msg_id_tok.str;
+	/* CTL messages have a slightly different format */
+	qm->is_ctl = is_ctl;
 	qm->type = message_type;
 	list_init(&qm->members);
 
@@ -572,7 +576,7 @@ void qmi_parse(void)
 	/* STRUCT ID<string> '{' ... '}' ';' */
 		/* TYPE<type*> ID<string> ';' */
 	/* MESSAGE ID<string> '{' ... '}' ';' */
-		/* (REQUIRED | OPTIONAL) TYPE<type*> ID<string> '=' NUM<num> ';' */
+		/* (REQUIRED | OPTIONAL) (CTL) TYPE<type*> ID<string> '=' NUM<num> ';' */
 
 	symbol_add("const", TOK_CONST);
 	symbol_add("optional", TOK_OPTIONAL);
@@ -580,6 +584,7 @@ void qmi_parse(void)
 	symbol_add("request", TOK_MESSAGE, MESSAGE_REQUEST);
 	symbol_add("response", TOK_MESSAGE, MESSAGE_RESPONSE);
 	symbol_add("indication", TOK_MESSAGE, MESSAGE_INDICATION);
+	symbol_add("ctl", TOK_CTL);
 	symbol_add("package", TOK_PACKAGE);
 	symbol_add("required", TOK_REQUIRED);
 	symbol_add("struct", TOK_STRUCT);

--- a/qmic.h
+++ b/qmic.h
@@ -49,6 +49,7 @@ struct qmi_message {
 	enum message_type type;
 	const char *name;
 	unsigned msg_id;
+	bool is_ctl;
 
 	struct list_head node;
 


### PR DESCRIPTION
Control packets use a single byte for the transaction ID instead of two,
support calling alternative handlers for these.

Comparing an example packet dump from qmicli (for the allocate CID command)
```
qmicli:        01 0F 00 00 00 00 00 01 22 00 04 00 01 01 00 0B
qmi_tlv (old):                   00 01 00 22 00 04 00 01 01 00 0b
qmi_tlv (new):                   00 01 22 00 04 00 01 01 00 0b
```

This RFC lets a message be defined as a control message if it has the token "ctl" before the message id. I considered a few approaches and this seems like the most sensible, I'm definitely open to suggestions.
